### PR TITLE
hiding events

### DIFF
--- a/eventary/templates/eventary/actions/events_editorial.html
+++ b/eventary/templates/eventary/actions/events_editorial.html
@@ -13,3 +13,10 @@
  title="{% blocktrans with event_title=event.title %}Update {{ event_title }}{% endblocktrans %}">
     <i class="glyphicon glyphicon-pencil"></i>
 </a>
+<a
+ class="btn btn-default btn-xs"
+ href="{% url 'eventary:editorial-hide_event' event.calendar.pk event.pk %}"
+ role="button"
+ title="{% blocktrans with event_title=event.title %}Hide {{ event_title }}{% endblocktrans %}">
+    <i class="glyphicon glyphicon-eye-close"></i>
+</a>

--- a/eventary/templates/eventary/actions/events_management.html
+++ b/eventary/templates/eventary/actions/events_management.html
@@ -15,6 +15,13 @@
 </a>
 <a
  class="btn btn-default btn-xs"
+ href="{% url 'eventary:editorial-hide_event' event.calendar.pk event.pk %}"
+ role="button"
+ title="{% blocktrans with event_title=event.title %}Hide {{ event_title }}{% endblocktrans %}">
+    <i class="glyphicon glyphicon-eye-close"></i>
+</a>
+<a
+ class="btn btn-default btn-xs"
  href="{% url 'eventary:editorial-delete_event' event.calendar.pk event.pk %}"
  role="button"
  title="{% blocktrans with event_title=event.title %}Delete {{ event_title }}{% endblocktrans %}">

--- a/eventary/urls.py
+++ b/eventary/urls.py
@@ -66,6 +66,11 @@ urlpatterns = [
         editorial.EventEditView.as_view(),
         name='editorial-update_event'
     ),
+    url(  # hides an event
+        r'^cal_(?P<calendar_pk>[0-9]+)/evt_(?P<pk>[0-9]+)/hide/$',
+        editorial.EventHideView.as_view(),
+        name='editorial-hide_event'
+    ),
     url(  # approves an event
         r'^cal_(?P<calendar_pk>[0-9]+)/evt_(?P<pk>[0-9]+)/publish/$',
         editorial.EventPublishView.as_view(),

--- a/eventary/views/editorial.py
+++ b/eventary/views/editorial.py
@@ -78,6 +78,7 @@ class EventEditView(EditorialOrManagementRequiredMixin, EventCreateView):
 
             # update the event using the form
             data = form_event.clean()
+            data['published'] = False
             Event.objects.filter(pk=kwargs.get('event_pk')).update(**data)
 
             # update the times using the form
@@ -136,6 +137,19 @@ class EventEditView(EditorialOrManagementRequiredMixin, EventCreateView):
                 'start_date', 'end_date', 'start_time', 'end_time'
             ]
         }
+
+
+class EventHideView(EditorialOrManagementRequiredMixin,
+                    SingleObjectMixin,
+                    View):
+
+    model = Event
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.object.published = False
+        self.object.save()
+        return redirect('eventary:redirector')
 
 
 class EventPublishView(EditorialOrManagementRequiredMixin,


### PR DESCRIPTION
when an event is edited, the publication status changes to `False`.
Also adds an action button for editors and administrators to hide events
(without needing to go to the edit view)