### PR TITLE
Improves wizard status pagination

### DIFF
--- a/eventary/templates/eventary/anonymous/create_event_wizard.html
+++ b/eventary/templates/eventary/anonymous/create_event_wizard.html
@@ -47,9 +47,9 @@
 
 <h1>{% blocktrans with calendar_title=calendar.title %}Propose an event for "{{ calendar_title }}"{% endblocktrans %}</h1>
 
-<form enctype="multipart/form-data" method="post">
+<form id="wizardform" enctype="multipart/form-data" method="post">
     {% csrf_token %}
-    {% wizard_status wizard wizard_steps_named valid_steps %}
+    {% wizard_status wizard wizard_steps_named valid_steps form_id="wizardform" %}
     {{ wizard.management_form }}
     {% if wizard.form.forms %}
         {{ wizard.form.management_form }}

--- a/eventary/templates/eventary/wizard_status.html
+++ b/eventary/templates/eventary/wizard_status.html
@@ -18,12 +18,13 @@
             {% endif %}
             title="{% blocktrans with step_name=name %}Go to {{ step_name }}.{% endblocktrans %}"
             name="wizard_submit_and_goto_step"
-            onclick="this.form.submit();"
+            onclick="document.getElementById('{{ form_id }}_clicked_link').setAttribute('value', this.getAttribute('data-step-number')); document.getElementById('{{ form_id }}').submit();"
         {% endif %}
-            value="{{ step }}">
+            data-step-number="{{ step }}">
         {{ name|capfirst }}
     </a>
     {% endfor %}
+    <input id="{{ form_id }}_clicked_link" type="hidden" name="wizard_submit_and_goto_step">
 </div>
 {% endif %}
 

--- a/eventary/templatetags/eventary_tags.py
+++ b/eventary/templatetags/eventary_tags.py
@@ -230,12 +230,13 @@ def url_replace(request, field, value):
 
 
 @register.simple_tag
-def wizard_status(wizard, named_steps, valid_steps=[]):
+def wizard_status(wizard, named_steps, valid_steps=[], form_id="wizardform"):
     """Renders a paginator (page navigation)"""
     return render_to_string('eventary/wizard_status.html',
                             context={'wizard': wizard,
                                      'named_steps': named_steps,
-                                     'valid_steps': valid_steps})
+                                     'valid_steps': valid_steps,
+                                     'form_id': form_id})
 
 
 @register.simple_tag


### PR DESCRIPTION
When using links, the value of the anchor is not sent as part data. This
adds an input hidden field, who's value is being modified to the value
of the clicked link.