### PR TITLE
fixes for deployment 31 may

### DIFF
--- a/eventary/templates/eventary/anonymous/published_event.ics
+++ b/eventary/templates/eventary/anonymous/published_event.ics
@@ -11,6 +11,6 @@ DTEND:{{ object.eventtimedate.start_date|date:"omd" }}T{{ object.eventtimedate.e
 DTEND:{{ object.eventtimedate.end_date|date:"omd" }}T{{ object.eventtimedate.end_time|time:"Hi"|default:"2000"}}00{% endif %}{% endif %}
 SUMMARY:{{ object.title }}{% if object.location %}
 LOCATION:{{ object.location }}{% endif %}{% if object.description %}
-DESCRIPTION:{{ object.description|striptags }}{% endif %}
+DESCRIPTION:{{ object.description|striptags|unescape|safe }}{% endif %}
 END:VEVENT
 END:VCALENDAR

--- a/eventary/templatetags/eventary_tags.py
+++ b/eventary/templatetags/eventary_tags.py
@@ -1,3 +1,5 @@
+import html
+
 from django import template
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -258,6 +260,11 @@ def pick(page, nr_picks=10):
 def to_rrule(recurrence):
     return ';'.join([str(rrule.to_dateutil_rrule()).split('\n')[-1]
                      for rrule in recurrence.recurrences.rrules])
+
+
+@register.filter(name='unescape')
+def unescape(text):
+    return html.unescape(text)
 
 
 #  Tags

--- a/eventary/views/mixins.py
+++ b/eventary/views/mixins.py
@@ -151,7 +151,11 @@ class FilterFormMixin(MultipleObjectMixin, FormMixin):
             event_pks = [
                 recurrence.event.pk
                 for recurrence in recurrences
-                if len(recurrence.recurrences.between(fdatetime, tdatetime))
+                if len(recurrence.recurrences.between(
+                    fdatetime,
+                    tdatetime,
+                    dtstart=fdatetime - timedelta(seconds=1)
+                ))
             ]
 
             return (Q(recurring=False) & (
@@ -179,7 +183,10 @@ class FilterFormMixin(MultipleObjectMixin, FormMixin):
                 for recurrence in recurrences
                 if len(recurrence.recurrences.between(
                     _to_datetime(recurrence.event.eventtimedate.start_date),
-                    tdatetime
+                    tdatetime,
+                    dtstart=_to_datetime(
+                        recurrence.event.eventtimedate.start_date
+                    ) - timedelta(seconds=1)
                 ))
             ]
 
@@ -205,7 +212,10 @@ class FilterFormMixin(MultipleObjectMixin, FormMixin):
             event_pk = [
                 recurrence.event.pk
                 for recurrence in recurrences
-                if recurrence.recurrences.after(fdatetime) is not None
+                if recurrence.recurrences.after(
+                    fdatetime,
+                    dtstart=fdatetime - timedelta(seconds=1)
+                ) is not None
             ]
 
             return (Q(recurring=False,


### PR DESCRIPTION
part 1: getting rid of html entities
.added a custom template tag to unescape html entities generated by the trix editor
.the safe filter is needed to prevent re-escaping after unescaping

part 2: fixing the appearance of recurring events
django-recurrence looks for events in the present or the future (as already discussed when fixing the sorting logic). this can be fixed by setting the `dtstart` argument in `.between` and `.after`. this fix was not implemented in the filtering logic, failing to display recurring events when the search time window was completely in the past. the `dtstart` argument is a for this issue: https://github.com/django-recurrence/django-recurrence/issues/50