### PR TITLE
Make the title more meaningful

### DIFF
--- a/eventary/templates/eventary/anonymous/published_event.html
+++ b/eventary/templates/eventary/anonymous/published_event.html
@@ -5,6 +5,8 @@
 {% load imagekit %}
 {% load static %}
 
+{% block 'title' %}{{ event.calendar.title }} | {{ event.title }}{% endblock %}
+
 {% block 'content' %}
 
 {% comment %}Translators: Event detail page{% endcomment %}


### PR DESCRIPTION
Since Solr weights the title of the page a lot, it is important to add
not only the title of the calendar, but the title of the event as well.