### PR TITLE
Improve title on event page for Solr indexing

### DIFF
--- a/eventary/templates/eventary/anonymous/published_event.html
+++ b/eventary/templates/eventary/anonymous/published_event.html
@@ -5,7 +5,7 @@
 {% load imagekit %}
 {% load static %}
 
-{% block 'title' %}{{ event.calendar.title }} | {{ event.title }}{% endblock %}
+{% block 'title' %}{{ event.title }} | {{ event.calendar.title }}{% endblock %}
 
 {% block 'content' %}
 


### PR DESCRIPTION
If the title of the calendar is displayed first, the title of the event
does not show up in the Solr list of results (because the combination of
both, event and calendar title is too long to be displayed).
By putting the title of the event upfront, the index should still find
the events by the title of the calendar, yet it will allow to display
the title of the event in the search results.

See also:
https://github.com/4teamwork/veranstaltungen_winterthur/issues/132