### PR TITLE
Keep filter querystring

### DIFF
--- a/eventary/templates/eventary/anonymous/published_event.html
+++ b/eventary/templates/eventary/anonymous/published_event.html
@@ -24,7 +24,7 @@
 <h1>{{ event.title }}</h1>
 
 <a class="btn btn-xs btn-default back-to-calendar-details"
-   href="{% url 'eventary:anonymous-calendar_details' event.calendar.pk %}"
+   href="{% url 'eventary:anonymous-calendar_details' event.calendar.pk %}{% if filter_querystring %}{{ filter_querystring }}{% endif %}"
    {% comment %}Translators: Title of link back to calendar details page{% endcomment %}
    title="{% blocktrans with calendar_title=event.calendar.title %}back to {{ calendar_title }}{% endblocktrans %}">
     <span class="glyphicon glyphicon-chevron-left">{% blocktrans with calendar_title=event.calendar.title %}back to {{ calendar_title }}{% endblocktrans %}</span>


### PR DESCRIPTION
The events can be filtered in the calendar view.
If a user clicks on an event after using the filter, the link to the
calendar should preserve the previously used filter.
To do so, the filter is read from the referer.