### PR TITLE
Fix removal of images

### DIFF
--- a/eventary/views/editorial.py
+++ b/eventary/views/editorial.py
@@ -156,7 +156,10 @@ class EventEditWizardView(EditorialOrManagementRequiredMixin,
             return os.path.split(_f)[1][-15:]
 
         if image is not None:
-            self.object.image.save(_file_name(image.name), image, save=True)
+            if image is False:
+                self.object.image.delete()
+            else:
+                self.object.image.save(_file_name(image.name), image, save=True)
         if document is not None:
             self.object.document.save(_file_name(document.name),
                                       document,


### PR DESCRIPTION
When an images is removed, the value of the field is a boolean (with the
value False).
The error happened when trying to access the image's name attribute,
which does not exist if the image is a boolean.
Therefore an attribute error was raised.
This fixes the error by removing the image when the field is False.