### PR TITLE
Fix the order of the groups.

### DIFF
--- a/eventary/forms.py
+++ b/eventary/forms.py
@@ -88,7 +88,7 @@ class FilterForm(forms.Form):
             grouping: [
                 (group.pk, group.title)
                 for group in sorted(_groupings[grouping],
-                                    key=lambda g: g.title)
+                                    key=lambda g: g.title.lower())
             ] for grouping in _groupings
         }
 
@@ -370,7 +370,8 @@ class EventGroupingForm(forms.Form):
             self._choices = {
                 grouping: [
                     (group.pk, group.title)
-                    for group in self._groupings[grouping]
+                    for group in sorted(self._groupings[grouping],
+                                        key=lambda g: g.title.lower())
                 ] for grouping in self._groupings
             }
 


### PR DESCRIPTION
Sorting of the groups has been introduced in https://github.com/4teamwork/django-eventary/pull/179 but we found another form where the sorting must be implemented too.

Furthermore we change the way the groups are sorted: by sorting by the lower cased title we get a more user friendly sorting for German group titles. Imagine the two group titles "LeseZeit" and "Leseförderung". Until now, "LeseZeit" would have come before "Leseförderung", which is kind of strange because the letter "z" should come after the letter "f" (because of ASCII, of course).