### PR TITLE
Fix the filter form when the search field contains umlauts.

### DIFF
--- a/eventary/views/mixins.py
+++ b/eventary/views/mixins.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from urllib.parse import unquote_plus
 
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.postgres.search import SearchVector
@@ -235,7 +236,7 @@ class FilterFormMixin(MultipleObjectMixin, FormMixin):
                 for grouping in self.object.grouping_set.all()
             ]
             data = {
-                key: self.request.GET.get(key)
+                key: unquote_plus(self.request.GET.get(key))
                 for key in self.request.GET
                 if '[]' not in key and key not in grouping_names
             }


### PR DESCRIPTION
The values in `request.GET` are quoted (`Töss` becomes `T%C3%B6ss`). Before prefilling the form field with the value from the query string, we need to unquote it. We use the `unquote_plus` function because spaces in the query string are replaced with the `+` sign.

❗️The bug only occurs if this application is running within a `ftw.duplexer.App`, so I cannot write a test for it.❗️

Closes https://extranet.4teamwork.ch/support/stadt-winterthur/tracker-web/126