### PR TITLE
Improve upload path (again).

### DIFF
--- a/eventary/models/base.py
+++ b/eventary/models/base.py
@@ -26,7 +26,7 @@ def _get_upload_path(event, filename):
         'calendar_{slug}'.format(slug=event.calendar.slug),
         'event_{slug}'.format(slug=event.slug),
         filename
-    )
+    ).replace(settings.MEDIA_ROOT, "")
 
 
 class Calendar(models.Model):


### PR DESCRIPTION
Until now the function returned an absolute path due to the usage of `safe_join`. This lead to wrong urls for the uploaded assets (containing a file system path). For the Django file field to work correctly, a path relative to `settings.MEDIA_ROOT` must be stored instead.