### PR TITLE
Fix removal of the event's document.

### DIFF
--- a/eventary/views/editorial.py
+++ b/eventary/views/editorial.py
@@ -161,9 +161,12 @@ class EventEditWizardView(EditorialOrManagementRequiredMixin,
             else:
                 self.object.image.save(_file_name(image.name), image, save=True)
         if document is not None:
-            self.object.document.save(_file_name(document.name),
-                                      document,
-                                      save=True)
+            if document is False:
+                self.object.document.delete()
+            else:
+                self.object.document.save(_file_name(document.name),
+                                          document,
+                                          save=True)
 
         # update the time and date
         data = form_dict['2'].clean()


### PR DESCRIPTION
When the user chooses to remove the event's document, the value of the form field is a boolean (with the value False). This case was not handled at all so it was never possible to remove the document because an exception occurred (attribute error).

The same error has been fixed for the event's image a few years ago (see https://github.com/4teamwork/django-eventary/pull/178).

Belongs to the PBI https://4teamwork.atlassian.net/browse/HG-1479

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/28220/128164433-a17986c6-2136-41b7-b64d-853298d8170b.png">
